### PR TITLE
fix to rrt_publisher declaration and definition

### DIFF
--- a/rrt_star_planner/include/rrt_star_planner/rrtstarplan.h
+++ b/rrt_star_planner/include/rrt_star_planner/rrtstarplan.h
@@ -96,6 +96,7 @@ namespace rrtstar_planner {
             costmap_2d::Costmap2D* costmap_;
             base_local_planner::WorldModel* world_model_;
             std::vector<geometry_msgs::Point> footprint;
+            ros::Publisher rrt_publisher;
 	};
 };
 

--- a/rrt_star_planner/src/rrtstarplan.cpp
+++ b/rrt_star_planner/src/rrtstarplan.cpp
@@ -45,6 +45,7 @@ void RRT::initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros)
             costmap_ros_ = costmap_ros; //initialize the costmap_ros_ attribute to the parameter.
             costmap_ = costmap_ros_->getCostmap(); //get the costmap_ from costmap_ros_
             footprint = costmap_ros_->getRobotFootprint();
+            rrt_publisher = pn.advertise<visualization_msgs::Marker> ("path_planner_rrt",1000);
 
         // initialize other planner parameters
         /*ros::NodeHandle private_nh("~/" + name);
@@ -561,7 +562,6 @@ bool RRT::makePlan(const geometry_msgs::PoseStamped& start, const geometry_msgs:
 
     plan.clear();
     rrtTree.clear();
-    ros::Publisher rrt_publisher = pn.advertise<visualization_msgs::Marker> ("path_planner_rrt",1000);
 
 	//defining markers
     visualization_msgs::Marker sourcePoint;


### PR DESCRIPTION
fixed rrt_publisher being assigned continuously in makePlan, moved instead into initialize and as a class member parameter.
the previous setup causes a non-publishing of the topic, I figured out it was an issue only of some versions of ROS, so since I have installed the noetic version, I created a pull-request in the branch noetic-devel.
Issue is fixed for me